### PR TITLE
.github: updated CI with placeholder functions

### DIFF
--- a/.github/workflows/git-push.yml
+++ b/.github/workflows/git-push.yml
@@ -33,62 +33,10 @@ jobs:
         run: |
           git config --global user.email "github.actions.runner@github.com"
           git config --global user.name "Github Action Automated Runner"
-      - name: Execute repo's AutomataCI - PURGE
-        id: native_ci_purge
+      - name: Execute placeholder
+        id: native_ci_placeholder
         run: |
-          ./automataCI/ci.sh.ps1 purge
-      - name: Execute repo's AutomataCI - CLEAN
-        id: native_ci_clean
-        run: |
-          ./automataCI/ci.sh.ps1 clean
-      - name: Execute repo's AutomataCI - ENVIRONMENT
-        id: native_ci_env
-        run: |
-          ./automataCI/ci.sh.ps1 env
-      - name: Execute repo's AutomataCI - SETUP
-        id: native_ci_setup
-        run: |
-          ./automataCI/ci.sh.ps1 setup
-      - name: Execute repo's AutomataCI - PREPARE
-        id: native_ci_prepare
-        run: |
-          ./automataCI/ci.sh.ps1 prepare
-      - name: Execute repo's AutomataCI - START
-        id: native_ci_start
-        run: |
-          ./automataCI/ci.sh.ps1 start
-      - name: Execute repo's AutomataCI - TEST
-        id: native_ci_test
-        run: |
-          ./automataCI/ci.sh.ps1 test
-      - name: Execute repo's AutomataCI - MATERIALIZE
-        id: native_ci_materialize
-        run: |
-          ./automataCI/ci.sh.ps1 materialize
-      - name: Execute repo's AutomataCI - BUILD
-        id: native_ci_build
-        run: |
-          ./automataCI/ci.sh.ps1 build
-      - name: Execute repo's AutomataCI - NOTARIZE
-        id: native_ci_notarize
-        run: |
-          ./automataCI/ci.sh.ps1 notarize
-      - name: Execute repo's AutomataCI - PACKAGE
-        id: native_ci_package
-        run: |
-          ./automataCI/ci.sh.ps1 package
-      - name: Execute repo's AutomataCI - RELEASE
-        id: native_ci_release
-        run: |
-          ./automataCI/ci.sh.ps1 release
-      - name: Execute repo's AutomataCI - STOP
-        id: native_ci_stop
-        run: |
-          ./automataCI/ci.sh.ps1 stop
-      - name: Execute repo's AutomataCI - DEPLOY
-        id: native_ci_deploy
-        run: |
-          ./automataCI/ci.sh.ps1 deploy
+          echo "hello world!\n"
       - name: Archive Payloads Artifacts
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Since we want to develop an update polygot script, we should change the current GitHub Actions to run a placeholder function instead until we have to bandwidth to develop one. Let's do this.

This patch updates CI with placeholder functions in .github/ directory.