### PR TITLE
display: backfilled all the source URLs

### DIFF
--- a/display/bungee-hairline/README.md
+++ b/display/bungee-hairline/README.md
@@ -21,6 +21,10 @@ The Bungee project is led by David Jonathan Ross, a type designer based in the
 USA. To contribute, see github.com/djrrb/Bungee
 
 
+The font is downloaded from:
+https://fonts.google.com/specimen/Bungee+Hairline/
+
+
 
 
 ## Designer

--- a/display/cinzel/README.md
+++ b/display/cinzel/README.md
@@ -8,6 +8,10 @@ onto it.
 To contribute, see github.com/NDISCOVER/Cinzel.
 
 
+The font is downloaded from:
+https://fonts.google.com/specimen/Cinzel/
+
+
 
 
 ## Designer


### PR DESCRIPTION
It appears there were some fonts did not specify their sources. Hence, let's backfill it.

This patch backfills all the source URLs in display/ directory.