### PR TITLE
display: corrected Bruno Ace font's designer credentials

### DIFF
--- a/display/bruno-ace/README.md
+++ b/display/bruno-ace/README.md
@@ -15,4 +15,4 @@ https://fonts.google.com/specimen/Bruno+Ace/
 
 
 ## Designer
-1. David Jonathan Ross - Principal Design
+1. Astigmatic - Principal Design


### PR DESCRIPTION
The Bruno Ace font's designer credentials was incorrect. Hence, we need to amend it.

This patch corrects Bruno Ace font's designer credentials in display/ directory.