### PR TITLE
root: implemented CI for update.sh.ps1

### DIFF
--- a/.github/workflows/git-push.yml
+++ b/.github/workflows/git-push.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           git config --global user.email "github.actions.runner@github.com"
           git config --global user.name "Github Action Automated Runner"
-      - name: Execute placeholder
-        id: native_ci_placeholder
+      - name: Execute Update Shell Script
+        id: native_ci_update_shell
         run: |
-          echo "hello world!\n"
+          ./update.sh.ps1
       - name: Archive Payloads Artifacts
         if: always()
         uses: actions/upload-artifact@v3

--- a/update.sh.ps1
+++ b/update.sh.ps1
@@ -32,7 +32,27 @@ echo \" <<'RUN_AS_POWERSHELL' >/dev/null # " | Out-Null
 ################################################################################
 # Windows POWERSHELL Codes                                                     #
 ################################################################################
-Write-Host "Hi! Please double click the font for installation. TQ"
+$Source = $PWD
+$Destination = "C:\Windows\Fonts"
+
+
+# Get the list from source files
+$___list = Get-ChildItem -Path $Source -Include ('*.ttf', '*.woff', '*.otf', '*.ttc') -Recurse
+foreach ($___file in $___list) {
+	$___dest = "${Destination}\$($___file.Name)"
+	if (-not (Test-Path -Path "${___dest}")) {
+		# copy the font file and install in.
+		Copy-Item -Path $___file.FullName -Destination "${___dest}"
+
+		# register the font for all users
+		New-ItemProperty `
+			-Path "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Fonts" `
+			-Name $___file.BaseName `
+			-PropertyType String `
+			-Value $___file.Name `
+			-Force
+	}
+}
 ################################################################################
 # Windows POWERSHELL Codes                                                     #
 ################################################################################


### PR DESCRIPTION
To make sure the shell script is working as expected across all known OSes, we have to implement the CI elements for it. Hence, let's do this.

This patch implements CI for update.sh.ps1 in root repository.